### PR TITLE
address hyp3-urls being multi-valued

### DIFF
--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -29,8 +29,8 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: |
           python publish_products_from_hyp3_to_asf.py \
-          --hyp3-urls https://hyp3-tibet-jpl.asf.alaska.edu \
           ${EARTHDATA_USERNAME} \
           ${EARTHDATA_PASSWORD} \
           ${TOPIC_ARN} \
-          ${RESPONSE_TOPIC_ARN}
+          ${RESPONSE_TOPIC_ARN} \
+          --hyp3-urls https://hyp3-tibet-jpl.asf.alaska.edu


### PR DESCRIPTION
`--hyp3-urls` is multi-valued (`nargs='+'`), so moving it to the end keeps it from eating the positional parameters

```
python publish_products_from_hyp3_to_asf.py \
  --hyp3-urls https://hyp3-tibet-jpl.asf.alaska.edu/ \
  ${EARTHDATA_USERNAME} \
  ${EARTHDATA_PASSWORD} \
  ${TOPIC_ARN} \
  ${RESPONSE_TOPIC_ARN}
  
publish_products_from_hyp3_to_asf.py: error: argument --hyp3-urls: invalid choice: '***' (choose from 'https://hyp3-a19-jpl.asf.alaska.edu/', 'https://hyp3-tibet-jpl.asf.alaska.edu/', 'https://hyp3-nisar-jpl.asf.alaska.edu/')
```