### PR TITLE
matrix for publsihing to handle more than one username

### DIFF
--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -8,14 +8,15 @@ on:
 env:
   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  EARTHDATA_USERNAME: ${{ secrets.EARTHDATA_USERNAME }}
-  EARTHDATA_PASSWORD: ${{ secrets.EARTHDATA_PASSWORD }}
-  TOPIC_ARN: ${{ secrets.TOPIC_ARN }}
-  RESPONSE_TOPIC_ARN: ${{ secrets.RESPONSE_TOPIC_ARN }}
 
 jobs:
   publish-products:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        environment: ['access19', 'disasters']
+    environment: ${{ matrix.environment }}
     steps:
       - uses: actions/checkout@v3
       - uses: aws-actions/configure-aws-credentials@v1
@@ -29,7 +30,7 @@ jobs:
       - run: python -m pip install -r requirements.txt
       - run: |
           python publish_products_from_hyp3_to_asf.py \
-          ${EARTHDATA_USERNAME} \
-          ${EARTHDATA_PASSWORD} \
-          ${TOPIC_ARN} \
-          ${RESPONSE_TOPIC_ARN}
+          ${{ secrets.EARTHDATA_USERNAME }} \
+          ${{ secrets.EARTHDATA_PASSWORD }} \
+          ${{ secrets.TOPIC_ARN }} \
+          ${{ secrets.RESPONSE_TOPIC_ARN }}


### PR DESCRIPTION
There are now multiple EDL usernames that will need their jobs published. This switches to using GitHub Environments and a matrix strategy to run this workflow in parallel for multiple usernames 

The reasoning for multiple users is discussed here: https://cloud-based-insar.slack.com/archives/C032TFGLHS8/p1668659855953759

--- 

TODOs:

**Before merge:**
- [x] Create an `access19` environment with `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` secrets
- [x] Create a `disasters` environment with `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` secrets

**After merge and successful run:**
- [ ] Remove `EARTHDATA_USERNAME` and `EARTHDATA_PASSWORD` *repository* secrets