### PR TITLE
publish products every two hours

### DIFF
--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -2,7 +2,7 @@ name: Publish products from HyP3 to ASF
 
 on:
   schedule:
-    - cron: '*/30 * * * *'
+    - cron: '0 */2 * * *'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
CMR search performance has been degraded the last month. This action has been regularly taking between 35-80 minutes, most of that time spent querying CMR for the complete GUNW inventory. This is a quick-fix to run the action less often.