### PR TITLE
publish ARIA_RAIDER jobs from hyp3-a19-jpl

### DIFF
--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -20,8 +20,8 @@ jobs:
             cmr_domain: https://cmr.earthdata.nasa.gov
             collection_short_name: ARIA_S1_GUNW
             hyp3_urls: https://hyp3-a19-jpl.asf.alaska.edu https://hyp3-tibet-jpl.asf.alaska.edu
-            job_type: INSAR_ISCE
-            start: 2024-01-01T00:00:00+00:00
+            job_type: INSAR_ISCE ARIA_RAIDER
+            start: 2024-04-01T00:00:00+00:00
 
     environment: ${{ matrix.environment }}
     steps:

--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -19,8 +19,14 @@ jobs:
           - environment: access19
             cmr_domain: https://cmr.earthdata.nasa.gov
             collection_short_name: ARIA_S1_GUNW
-            hyp3_urls: https://hyp3-a19-jpl.asf.alaska.edu https://hyp3-tibet-jpl.asf.alaska.edu
+            hyp3_urls: https://hyp3-a19-jpl.asf.alaska.edu
             job_type: INSAR_ISCE ARIA_RAIDER
+            start: 2024-04-01T00:00:00+00:00
+          - environment: access19
+            cmr_domain: https://cmr.earthdata.nasa.gov
+            collection_short_name: ARIA_S1_GUNW
+            hyp3_urls: https://hyp3-tibet-jpl.asf.alaska.edu
+            job_type: INSAR_ISCE
             start: 2024-04-01T00:00:00+00:00
 
     environment: ${{ matrix.environment }}

--- a/publish_products_from_hyp3_to_asf.py
+++ b/publish_products_from_hyp3_to_asf.py
@@ -106,8 +106,8 @@ def get_args():
     parser = argparse.ArgumentParser()
     parser.add_argument('--cmr-domain', default='https://cmr.earthdata.nasa.gov',
                         choices=['https://cmr.earthdata.nasa.gov', 'https://cmr.uat.earthdata.nasa.gov'])
-    parser.add_argument('--job-type', default='INSAR_ISCE',
-                        choices=['INSAR_ISCE', 'INSAR_ISCE_TEST'])
+    parser.add_argument('--job-type', nargs='+', default=['INSAR_ISCE'],
+                        choices=['INSAR_ISCE', 'ARIA_RAIDER'])
     parser.add_argument('--start', type=parse_datetime)
     parser.add_argument('--collection-short-name', default='ARIA_S1_GUNW',
                         choices=['ARIA_S1_GUNW'])


### PR DESCRIPTION
python script:
- removes `INSAR_ISCE_TEST` from list of job types; that job type is no longer available in the hyp3-19-jpl, hyp3-tibet-jpl, or hyp3-nisar-jpl deployments
- adds `ARIA_RAIDER` to the list of possible job type
- makes `--job-type` multi-values

job setup:
- adds ARIA_RAIDER to the list of published job types
- updates the start date to 2024-04-01 from 2024-01-01 to speed up querying HyP3 for candidate jobs to publish