### PR TITLE
publish ARIA_RAIDER jobs from hyp3-a19-jpl deployment

### DIFF
--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -27,7 +27,7 @@ jobs:
             collection_short_name: ARIA_S1_GUNW
             hyp3_urls: https://hyp3-a19-jpl.asf.alaska.edu
             job_type: ARIA_RAIDER
-            start: 2024-01-01T00:00:00+00:00
+            start: 2024-05-01T00:00:00+00:00
 
     environment: ${{ matrix.environment }}
     steps:

--- a/.github/workflows/publish-products-from-hyp3-to-asf.yml
+++ b/.github/workflows/publish-products-from-hyp3-to-asf.yml
@@ -22,6 +22,12 @@ jobs:
             hyp3_urls: https://hyp3-a19-jpl.asf.alaska.edu https://hyp3-tibet-jpl.asf.alaska.edu
             job_type: INSAR_ISCE
             start: 2024-01-01T00:00:00+00:00
+          - environment: access19
+            cmr_domain: https://cmr.earthdata.nasa.gov
+            collection_short_name: ARIA_S1_GUNW
+            hyp3_urls: https://hyp3-a19-jpl.asf.alaska.edu
+            job_type: ARIA_RAIDER
+            start: 2024-01-01T00:00:00+00:00
 
     environment: ${{ matrix.environment }}
     steps:

--- a/publish_products_from_hyp3_to_asf.py
+++ b/publish_products_from_hyp3_to_asf.py
@@ -107,7 +107,7 @@ def get_args():
     parser.add_argument('--cmr-domain', default='https://cmr.earthdata.nasa.gov',
                         choices=['https://cmr.earthdata.nasa.gov', 'https://cmr.uat.earthdata.nasa.gov'])
     parser.add_argument('--job-type', default='INSAR_ISCE',
-                        choices=['INSAR_ISCE', 'INSAR_ISCE_TEST'])
+                        choices=['INSAR_ISCE', 'ARIA_RAIDER'])
     parser.add_argument('--start', type=parse_datetime)
     parser.add_argument('--collection-short-name', default='ARIA_S1_GUNW',
                         choices=['ARIA_S1_GUNW'])


### PR DESCRIPTION
Test run identified the correct products to be published. Same number of results with a start date of `2024-01-01` or `2024-05-01`.

```
$ python publish_products_from_hyp3_to_asf.py --cmr-domain https://cmr.earthdata.nasa.gov --job-type ARIA_RAIDER --start=2024-01-01T00:00:00+00:00 --hyp3-urls https://hyp3-a19-jpl.asf.alaska.edu --dry-run <user> <password> foo arn:aws:sns:us-east-1:accountId:topicName
Querying ['https://hyp3-a19-jpl.asf.alaska.edu'] as user <user> for GUNW products (ARIA_RAIDER jobs) since 2024-01-01 00:00:00+00:00
Found 49387 products
Querying https://cmr.earthdata.nasa.gov for GUNW products in collection ARIA_S1_GUNW
Found 236495 products in CMR
Publishing 49382 products to foo
```